### PR TITLE
refactor template and slot

### DIFF
--- a/wxml/generate.js
+++ b/wxml/generate.js
@@ -74,15 +74,15 @@ function generateNode(node, state, asset, nextNode) {
     return `${compiled}`
   } else if (node.name === "template") {
     const is = node.attributes.is
-    const name = is ? '"' + getName(asset, "template", is) + '"' : null
-    let code = name ? `{window.remotes[${name}]()}` : ""
-    if (node.children) {
-      code += `${node.children
+    if (is) {
+      const name = is ? '"' + getName(asset, "template", is) + '"' : null
+      is && asset.symbols.set(is, getName(asset, "template", is))
+      return `{window.remotes[${name}]()}`
+    } else {
+      return node.children
         .map((item) => generateNode(item, state, asset))
-        .join("\n")}`
+        .join("\n")
     }
-    is && asset.symbols.set(is, getName(asset, "template", is))
-    return code
   } else {
     let code = `<${titleCase(node.name)} `
     code += generateProps(node, state, asset)

--- a/wxml/generate.js
+++ b/wxml/generate.js
@@ -9,8 +9,8 @@ function generate(asset) {
   let tree = asset.ast
   let tag = asset.parent.tag
   let children = tree.children
-  let isTemplate = tree.children[0].name === "template"
-
+  let iskid = asset.parent.type === "wxml"
+  
   let state = {
     imports: [],
     methods: [],
@@ -27,7 +27,7 @@ function generate(asset) {
   code += "</>"
 
   let { imports, methods } = state
-  let hook = generateHook(tag, methods, isTemplate)
+  let hook = generateHook(tag, methods, iskid)
   return { hook, code, imports }
 }
 
@@ -49,7 +49,7 @@ function lifeCode() {
   }
 }
 
-function generateHook(tag, methods, isTemplate) {
+function generateHook(tag, methods, iskid) {
   let { life, code } = lifeCode(tag)
   let decode
   if (tag) {
@@ -58,7 +58,7 @@ function generateHook(tag, methods, isTemplate) {
     )}},${life}} = useComponent(fre.useState({})[1], props,'${tag}')`
   } else {
     decode = `const {data, ${life}, ${methods.join(",")}} = usePage(${
-      isTemplate ? "null" : "fre.useState({})[1]"
+      iskid ? "null" : "fre.useState({})[1]"
     }, props)`
   }
   return isTemplate
@@ -79,6 +79,8 @@ function generateNode(node, state, asset, nextNode) {
       is && asset.symbols.set(is, getName(asset, "template", is))
       return `{window.remotes[${name}]()}`
     } else {
+      // const name = asset.parent.symbols.get(node.attributes.name)
+
       return node.children
         .map((item) => generateNode(item, state, asset))
         .join("\n")

--- a/wxml/generate.js
+++ b/wxml/generate.js
@@ -10,7 +10,7 @@ function generate(asset) {
   let tag = asset.parent.tag
   let children = tree.children
   let iskid = asset.parent.type === "wxml"
-  
+
   let state = {
     imports: [],
     methods: [],
@@ -31,7 +31,8 @@ function generate(asset) {
   return { hook, code, imports }
 }
 
-function lifeCode() {
+function lifeCode(methods) {
+  let method = methods.join(",")
   let life = `onLoad,onUnload,onShow,onHide`
   let code = `fre.useEffect(()=>{
     const params = window.getUrl(window.location.href)
@@ -46,18 +47,17 @@ function lifeCode() {
   return {
     life,
     code,
+    method,
   }
 }
 
 function generateHook(tag, methods, iskid) {
-  let { life, code } = lifeCode(tag)
+  let { life, code, method } = lifeCode(methods)
   let decode
   if (tag) {
-    decode = `const {properties:data, methods:{${methods.join(
-      ","
-    )}},${life}} = useComponent(fre.useState({})[1], props,'${tag}')`
+    decode = `const {properties:data, methods:{${method}},${life}} = useComponent(fre.useState({})[1], props,'${tag}')`
   } else {
-    decode = `const {data, ${life}, ${methods.join(",")}} = usePage(${
+    decode = `const {data, ${life}, ${method}} = usePage(${
       iskid ? "null" : "fre.useState({})[1]"
     }, props)`
   }

--- a/wxml/generate.js
+++ b/wxml/generate.js
@@ -53,17 +53,17 @@ function lifeCode(methods) {
 
 function generateHook(tag, methods, iskid) {
   let { life, code, method } = lifeCode(methods)
-  let decode
+  let constant
   if (tag) {
-    decode = `const {properties:data, methods:{${method}},${life}} = useComponent(fre.useState({})[1], props,'${tag}')`
+    constant = `const {properties:data, methods:{${method}},${life}} = useComponent(fre.useState({})[1], props,'${tag}')`
   } else {
-    decode = `const {data, ${life}, ${method}} = usePage(${
+    constant = `const {data, ${life}, ${method}} = usePage(${
       iskid ? "null" : "fre.useState({})[1]"
     }, props)`
   }
-  return isTemplate
-    ? `${decode}`
-    : `${decode}
+  return iskid
+    ? `${constant}`
+    : `${constant}
     ${code}
     `
 }

--- a/wxml/generate.js
+++ b/wxml/generate.js
@@ -75,12 +75,10 @@ function generateNode(node, state, asset, nextNode) {
   } else if (node.name === "template") {
     const is = node.attributes.is
     if (is) {
-      const name = is ? '"' + getName(asset, "template", is) + '"' : null
-      is && asset.symbols.set(is, getName(asset, "template", is))
+      const name ='"' + getName(asset, "template", is) + '"'
+      asset.symbols.set(is, getName(asset, "template", is))
       return `{window.remotes[${name}]()}`
     } else {
-      // const name = asset.parent.symbols.get(node.attributes.name)
-
       return node.children
         .map((item) => generateNode(item, state, asset))
         .join("\n")


### PR DESCRIPTION
重构 template 和 slot，因为这俩比较相似，所以可以概括到一起搞

主要思想是使用 module federation

```js
// 插槽
<view slot="aaa"/>
<slot name = "aaa"/>

// template
<template name="bbb"/>
<template is="bbb">
```