### PR TITLE
remove ast ops

### DIFF
--- a/core/plugins/esbuild-component-tag.js
+++ b/core/plugins/esbuild-component-tag.js
@@ -6,11 +6,10 @@ module.exports = options => {
         setup(build) {
             build.onLoad({ filter: /.+/ }, async ({ path }) => {
                 const source = await fs.promises.readFile(path, "utf8")
-                const code = source.
-                    replace('Component(', `Component('${options.id}','${options.tag}','${options.pid}', `)
-                    .replace('Page(', `Page('${options.id}', `)
+                const pagecode = `\nPage.id="${options.id}"\n` + source
+                const componentcode = `\nComponent.id="${options.id}"\nComponent.pid="${options.pid}"\nComponent.tag="${options.tag || ''}"\n` + source
                 return {
-                    contents: code,
+                    contents: options.tag ? componentcode : pagecode,
                 }
             })
         }


### PR DESCRIPTION
删掉了唯一的ast操作，esbuild 不支持 ast 还是很鸡肋的，幸好 wean 可以完全避免 ast